### PR TITLE
Better PowerShell detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Viet Tran <tdviet@gmail.com>
 Enol Fernandez <enol.fernandez@egi.eu>
+Levente Farkas <levente.farkas@egi.eu>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.9]
+- Outputs platform-specific set environment commands
+- Better help messages
+
 ## [1.2.0]
 - New JSON output
 - Code cleaning
@@ -7,7 +11,6 @@
 ## [1.1.2]
 - Changing CHECKIN_* to OIDC_*
 - Start deprecation of using refresh token
-
 
 ## [1.1.1]
 - Small bug fixes and documentation update
@@ -30,7 +33,6 @@
 ## [1.0.1]
 - Multi-thread execution of OpenStack all-sites operation
 - Update documentation
-
 
 ## [1.0.00]
 - First public release

--- a/fedcloudclient/checkin.py
+++ b/fedcloudclient/checkin.py
@@ -21,7 +21,7 @@ from fedcloudclient.decorators import (
 
 def oidc_discover(oidc_url):
     """
-    Discover oidc endpoints
+    Discover OIDC endpoints
 
     :param oidc_url: CheckIn URL
     :return: JSON object of OIDC configuration
@@ -90,9 +90,9 @@ def get_access_token(
     oidc_agent_account,
 ):
     """
-    Getting access token.
-    Generate new access token from oidc-agent or refresh token (if given)
-    or use existing token
+    Get access token
+    Generates new access token from oidc-agent or
+    refresh token (if given), or use existing token
 
     Check expiration time of access token
     Raise error if no valid token exists
@@ -122,8 +122,7 @@ def get_access_token(
     # Then try refresh token
     if oidc_refresh_token and oidc_client_id and oidc_client_secret and oidc_url:
         print(
-            "WARNING: exposing refresh tokens is insecure and will be disabled in "
-            "next version!",
+            "Warning: Exposing refresh tokens is insecure and will be deprecated!",
             file=sys.stderr,
         )
         return token_refresh(
@@ -182,7 +181,7 @@ def token_list_vos(oidc_access_token, oidc_url):
 @click.group()
 def token():
     """
-    Token command group for manipulation with tokens
+    Get details of access/refresh tokens
     """
     pass
 
@@ -192,7 +191,7 @@ def token():
 @oidc_access_token_params
 def check(oidc_refresh_token, oidc_access_token):
     """
-    CLI command for printing validity of access or refresh token
+    Check validity of access/refresh token
     """
 
     if oidc_refresh_token:
@@ -252,7 +251,7 @@ def list_vos(
     oidc_agent_account,
 ):
     """
-    CLI command for listing VO memberships according to access token
+    List VO membership(s) of access token
     """
     oidc_access_token = get_access_token(
         oidc_access_token,

--- a/fedcloudclient/cli.py
+++ b/fedcloudclient/cli.py
@@ -20,7 +20,6 @@ cli.add_command(token)
 cli.add_command(endpoint)
 cli.add_command(ec3)
 cli.add_command(site)
-
 cli.add_command(openstack)
 cli.add_command(openstack_int)
 

--- a/fedcloudclient/decorators.py
+++ b/fedcloudclient/decorators.py
@@ -131,7 +131,7 @@ def oidc_params(func):
     )
     @click.option(
         "--oidc-agent-account",
-        help="short account name in oidc-agent",
+        help="Account name in oidc-agent",
         envvar="OIDC_AGENT_ACCOUNT",
     )
     @functools.wraps(func)
@@ -151,21 +151,21 @@ def openstack_params(func):
 
     @click.option(
         "--openstack-auth-protocol",
-        help="Check-in protocol",
+        help="Authentication protocol",
         envvar="OPENSTACK_AUTH_PROTOCOL",
         default=DEFAULT_PROTOCOL,
         show_default=True,
     )
     @click.option(
         "--openstack-auth-type",
-        help="Check-in authentication type",
+        help="Authentication type",
         envvar="OPENSTACK_AUTH_TYPE",
         default=DEFAULT_AUTH_TYPE,
         show_default=True,
     )
     @click.option(
         "--openstack-auth-provider",
-        help="Check-in identity provider",
+        help="Identity provider",
         envvar="OPENSTACK_AUTH_PROVIDER",
         default=DEFAULT_IDENTITY_PROVIDER,
         show_default=True,

--- a/fedcloudclient/ec3.py
+++ b/fedcloudclient/ec3.py
@@ -79,7 +79,7 @@ configure front (
 @click.group()
 def ec3():
     """
-    EC3 related comands
+    EC3 cluster provisioning
     """
     pass
 
@@ -97,7 +97,7 @@ def refresh(
     auth_file,
 ):
     """
-    Refreshing token in EC3 authorization file
+    Refresh token in EC3 authorization file
     """
     # Get the right endpoint from GOCDB
     auth_file_contents = []
@@ -161,12 +161,16 @@ def init(
     force,
 ):
     """
-    Creating EC3 authorization file and template
+    Create EC3 authorization file and template
     """
     if os.path.exists(auth_file) and not force:
         print(
             "Auth file already exists, not replacing unless --force option is included"
         )
+        raise click.Abort()
+
+    if site == "ALL_SITES":
+        print("EC3 commands cannot be used with ALL_SITES")
         raise click.Abort()
 
     access_token = get_access_token(
@@ -177,10 +181,6 @@ def init(
         oidc_url,
         oidc_agent_account,
     )
-
-    if site == "ALL_SITES":
-        print("ec3 command cannot be used with ALL_SITES")
-        raise click.Abort()
 
     endpoint, project_id, protocol = find_endpoint_and_project_id(site, vo)
     site_auth = [

--- a/fedcloudclient/endpoint.py
+++ b/fedcloudclient/endpoint.py
@@ -8,7 +8,6 @@ test on sites
 """
 
 import os
-import re
 from urllib import parse
 
 import click

--- a/fedcloudclient/endpoint.py
+++ b/fedcloudclient/endpoint.py
@@ -17,7 +17,6 @@ import requests
 from fedcloudclient.checkin import get_access_token, oidc_params
 from fedcloudclient.decorators import project_id_params, site_params
 from fedcloudclient.shell import printSetEnvCommand
-from fedcloudclient.shell import printComment
 from tabulate import tabulate
 
 GOCDB_PUBLICURL = "https://goc.egi.eu/gocdbpi/public/"
@@ -244,7 +243,9 @@ def projects(
         print(tabulate(project_list, headers=["id", "Name", "enabled", "site"]))
     else:
         print("Error: You probably do not have access to any project at site %s" % site)
-        print('Check your access token and VO memberships using "fedcloud token list-vos"')
+        print(
+            'Check your access token and VO memberships using "fedcloud token list-vos"'
+        )
 
 
 @endpoint.command()

--- a/fedcloudclient/endpoint.py
+++ b/fedcloudclient/endpoint.py
@@ -17,6 +17,7 @@ import requests
 from fedcloudclient.checkin import get_access_token, oidc_params
 from fedcloudclient.decorators import project_id_params, site_params
 from fedcloudclient.shell import printSetEnvCommand
+from fedcloudclient.shell import printComment
 from tabulate import tabulate
 
 GOCDB_PUBLICURL = "https://goc.egi.eu/gocdbpi/public/"
@@ -89,7 +90,7 @@ def find_endpoint(service_type, production=True, monitored=True, site=None):
 
 def get_keystone_url(os_auth_url, path):
     """
-    Helper function for fixing keystone URL
+    Helper function for fixing Keystone URL
     """
     url = parse.urlparse(os_auth_url)
     prefix = url.path.rstrip("/")
@@ -101,7 +102,7 @@ def get_keystone_url(os_auth_url, path):
 
 def get_unscoped_token(os_auth_url, access_token):
     """
-    Get an unscoped token, trying various protocol names if needed
+    Get an unscoped token, will try all protocols if needed
     """
     protocols = ["openid", "oidc"]
     for p in protocols:
@@ -115,7 +116,7 @@ def get_unscoped_token(os_auth_url, access_token):
 
 def get_scoped_token(os_auth_url, access_token, project_id):
     """
-    Get a scoped token, trying various protocol names if needed
+    Get a scoped token, will try all protocols if needed
     """
     unscoped_token, protocol = get_unscoped_token(os_auth_url, access_token)
     url = get_keystone_url(os_auth_url, "/v3/auth/tokens")
@@ -161,7 +162,7 @@ def get_projects(os_auth_url, unscoped_token):
 
 def get_projects_from_sites(access_token, site):
     """
-    Get all projects from sites using access token
+    Get all projects from site(s) using access token
     """
     project_list = []
     for ep in find_endpoint("org.openstack.nova", site=site):
@@ -181,7 +182,7 @@ def get_projects_from_sites(access_token, site):
 
 def get_projects_from_sites_dict(access_token, site):
     """
-    Get all projects as a dictionary from sites using access token,
+    Get all projects as a dictionary from site(s) using access token
     """
     project_list = []
     for ep in find_endpoint("org.openstack.nova", site=site):
@@ -204,27 +205,10 @@ def get_projects_from_sites_dict(access_token, site):
     return project_list
 
 
-def get_project_id_from_vo_site(access_token, vo, site):
-    """
-    Deprecated in favor of new functions in sites.py
-
-    Get project ID from site ID and VO name
-    """
-    if site is None:
-        return None
-    project_list = get_projects_from_sites(access_token, site)
-    m = re.compile("^(VO:|vo_)*" + vo + "$")
-    for project in project_list:
-        if m.match(project[1]):
-            print(project)
-            return project[0]
-    return None
-
-
 @click.group()
 def endpoint():
     """
-    endpoint command group for interaction with GOCDB and endpoints
+    Obtain endpoint details and scoped tokens
     """
     pass
 
@@ -242,7 +226,7 @@ def projects(
     site,
 ):
     """
-    List of all project from specific site/sites
+    List projects from site(s)
     """
     access_token = get_access_token(
         oidc_access_token,
@@ -260,9 +244,7 @@ def projects(
         print(tabulate(project_list, headers=["id", "Name", "enabled", "site"]))
     else:
         print("Error: You probably do not have access to any project at site %s" % site)
-        print(
-            'Check your access token and VO memberships via command "fedcloud token list-vos"'
-        )
+        print('Check your access token and VO memberships using "fedcloud token list-vos"')
 
 
 @endpoint.command()
@@ -280,8 +262,13 @@ def token(
     project_id,
 ):
     """
-    Get scoped keystone token from site and project ID
+    Get scoped Keystone token for site and project
     """
+    if site == "ALL_SITES":
+        print("Cannot get tokens for ALL_SITES")
+        raise click.Abort()
+
+    # Get an access token
     access_token = get_access_token(
         oidc_access_token,
         oidc_refresh_token,
@@ -298,7 +285,7 @@ def token(
         scoped_token, _ = get_scoped_token(os_auth_url, access_token, project_id)
         printSetEnvCommand("OS_TOKEN", scoped_token)
     except RuntimeError:
-        print("Error: Unable to get keystone token from site %s " % site)
+        print("Error: Unable to get Keystone token from site %s " % site)
 
 
 @endpoint.command()
@@ -323,7 +310,7 @@ def token(
 @site_params
 def list(service_type, production, monitored, site):
     """
-    List of endpoints of site/sites according info in GOCDB
+    List endpoints in site(s), will query GOCDB
     """
     if site == "ALL_SITES":
         site = None
@@ -347,9 +334,13 @@ def env(
     project_id,
 ):
     """
-    Generating OS environment variables for specific project/site
+    Generate OS environment variables for site and project
     """
+    if site == "ALL_SITES":
+        print("Cannot generate environment variables for ALL_SITES")
+        raise click.Abort()
 
+    # Get an access token
     access_token = get_access_token(
         oidc_access_token,
         oidc_refresh_token,
@@ -366,11 +357,11 @@ def env(
     try:
         scoped_token, protocol = get_scoped_token(os_auth_url, access_token, project_id)
         print("# environment for %s" % site)
+        printSetEnvCommand("OS_PROJECT_ID", project_id)
         printSetEnvCommand("OS_AUTH_URL", os_auth_url)
         printSetEnvCommand("OS_AUTH_TYPE", "v3oidcaccesstoken")
         printSetEnvCommand("OS_IDENTITY_PROVIDER", "egi.eu")
         printSetEnvCommand("OS_PROTOCOL", protocol)
         printSetEnvCommand("OS_ACCESS_TOKEN", access_token)
-        printSetEnvCommand("OS_PROJECT_ID", project_id)
     except RuntimeError:
-        print("Error: Unable to get keystone token from site %s " % site)
+        print("Error: Unable to get Keystone token from site %s " % site)

--- a/fedcloudclient/openstack.py
+++ b/fedcloudclient/openstack.py
@@ -124,9 +124,9 @@ def fedcloud_openstack(
     oidc_access_token, site, vo, openstack_command, json_output=True
 ):
     """
-    Simplified version of fedcloud_openstack_full() function using
+    Simplified version of fedcloud_openstack_full() using
     default EGI setting for identity provider and protocols
-    Call openstack client with default options for EGI Check-in
+    Calls OpenStack CLI with default options for EGI Check-in
 
     :param oidc_access_token: Checkin access token.
            Passed to openstack client as --os-access-token
@@ -229,7 +229,7 @@ def print_result(
 @click.option(
     "--json-output",
     "-j",
-    help="Print output as a big JSON object",
+    help="Print output as JSON object",
     is_flag=True,
 )
 @click.argument("openstack_command", required=True, nargs=-1)
@@ -250,7 +250,7 @@ def openstack(
     openstack_command,
 ):
     """
-    Executing OpenStack commands on site and VO
+    Execute OpenStack commands on site and VO
     """
 
     if not check_openstack_client_installation():

--- a/fedcloudclient/shell.py
+++ b/fedcloudclient/shell.py
@@ -22,7 +22,7 @@ def getShellType():
 
         if bool(re.match("pwsh*|pwsh.exe|powershell.exe", parentName)):
             return Shell.PowerShell
-        
+
         return Shell.WindowsCommandPrompt
 
     return Shell.Linux
@@ -40,6 +40,7 @@ def printSetEnvCommand(name, value):
         print(f'$Env:{name!s}="{value!s}";')
     else:
         print(f"set {name!s}={value!s}")
+
 
 def printComment(comment):
     """

--- a/fedcloudclient/shell.py
+++ b/fedcloudclient/shell.py
@@ -40,3 +40,16 @@ def printSetEnvCommand(name, value):
         print(f'$Env:{name!s}="{value!s}";')
     else:
         print(f"set {name!s}={value!s}")
+
+def printComment(comment):
+    """
+    Print comment command,
+    format it correctly for the current platfom
+    """
+    shellType = getShellType()
+    if shellType == Shell.Linux:
+        print(f"# {comment!s}")
+    elif shellType == Shell.PowerShell:
+        print(f"# {comment!s}")
+    else:
+        print(f"rem {comment!s}")

--- a/fedcloudclient/shell.py
+++ b/fedcloudclient/shell.py
@@ -20,10 +20,10 @@ def getShellType():
         parentProc = os.getppid()
         parentName = Process(parentProc).name()
 
-        if bool(re.fullmatch("pwsh|pwsh.exe|powershell.exe", parentName)):
+        if bool(re.match("pwsh*|pwsh.exe|powershell.exe", parentName)):
             return Shell.PowerShell
-        else:
-            return Shell.WindowsCommandPrompt
+        
+        return Shell.WindowsCommandPrompt
 
     return Shell.Linux
 

--- a/fedcloudclient/sites.py
+++ b/fedcloudclient/sites.py
@@ -25,7 +25,7 @@ from fedcloudclient.decorators import (
     site_params,
     site_vo_params,
 )
-from fedcloudclient.shell import printSetEnvCommand, printComment
+from fedcloudclient.shell import printComment, printSetEnvCommand
 from jsonschema import validate
 
 __REMOTE_CONFIG_FILE = (

--- a/fedcloudclient/sites.py
+++ b/fedcloudclient/sites.py
@@ -26,6 +26,7 @@ from fedcloudclient.decorators import (
     site_vo_params,
 )
 from fedcloudclient.shell import printSetEnvCommand
+from fedcloudclient.shell import printComment
 from jsonschema import validate
 
 __REMOTE_CONFIG_FILE = (
@@ -73,7 +74,8 @@ def read_site_config():
 
 def safe_read_yaml_from_url(url, max_length):
     """
-    Safe reading from URL. Check URL and size before reading
+    Safe reading from URL
+    Check URL and size before reading
 
     :param url:
     :param max_length:
@@ -103,8 +105,8 @@ def safe_read_yaml_from_url(url, max_length):
 
 def read_default_site_config():
     """
-    Read default site configurations from GitHub.  Storing
-    site configurations in a global variable, that will be used by other functions
+    Read default site configurations from GitHub
+    Storing site configurations in a global variable that will be used by other functions
 
     :return: None
     """
@@ -132,8 +134,8 @@ def read_default_site_config():
 
 def read_local_site_config(config_dir):
     """
-    Read site configurations from local directory specified in config_dir. Storing
-    site configurations in global variable, that will be used by other functions
+    Read site configurations from local directory specified in config_dir
+    Storing site configurations in global variable, that will be used by other functions
 
     :param config_dir: path to directory containing site configuration
     :return: None
@@ -154,7 +156,7 @@ def read_local_site_config(config_dir):
 
 def save_site_config(config_dir):
     """
-    Save site configs to local directory specified in config_dir.
+    Save site configs to local directory specified in config_dir
     Overwrite local configs if exist
 
     :param config_dir: path to directory containing site configuration
@@ -170,7 +172,7 @@ def save_site_config(config_dir):
 
 def delete_site_config(config_dir):
     """
-    Delete site configs to local directory specified in config_dir.
+    Delete site configs to local directory specified in config_dir
 
     :param config_dir: path to directory containing site configuration
     :return: None
@@ -212,8 +214,8 @@ def find_endpoint_and_project_id(site_name, vo):
     to site configuration
 
     :param site_name: site ID in GOCDB
-    :param vo: VO name. None if finding only site endpoint
-    :return: endpoint, project_id, protocol if the VO exist on the site,
+    :param vo: VO name or None to find site endpoint only
+    :return: endpoint, project_id, protocol if the VO has access to the site,
              otherwise None, None, None
     """
     site_info = find_site_data(site_name)
@@ -229,14 +231,14 @@ def find_endpoint_and_project_id(site_name, vo):
         if vo_info["name"] == vo:
             return site_info["endpoint"], vo_info["auth"]["project_id"], protocol
 
-    # Return None, None if VO not found
+    # Return None if VO not found among those that have access to site
     return None, None, None
 
 
 @click.group()
 def site():
     """
-    Site command group for manipulation with site configurations
+    Obtain site configurations
     """
     pass
 
@@ -245,8 +247,15 @@ def site():
 @site_params
 def show(site):
     """
-    Print configuration of the specified site
+    Print configuration of specified site(s)
     """
+    if site == "ALL_SITES":        
+        read_site_config()
+        for site_info in __site_config_data:
+            site_info_str = yaml.dump(site_info, sort_keys=True)
+            print(site_info_str)
+        return 0
+
     site_info = find_site_data(site)
     if site_info:
         print(yaml.dump(site_info, sort_keys=True))
@@ -259,7 +268,7 @@ def show(site):
 @site_vo_params
 def show_project_id(site, vo):
     """
-    Printing Keystone endpoint and project ID of the VO on the site
+    Print Keystone endpoint and project ID
     """
     endpoint, project_id, protocol = find_endpoint_and_project_id(site, vo)
     if endpoint:
@@ -271,21 +280,10 @@ def show_project_id(site, vo):
 
 
 @site.command()
-def show_all():
-    """
-    Print all site configuration
-    """
-    read_site_config()
-    for site_info in __site_config_data:
-        site_info_str = yaml.dump(site_info, sort_keys=True)
-        print(site_info_str)
-
-
-@site.command()
 def save_config():
     """
-    Read default site configs from GitHub and save them to local folder in $HOME
-    Overwrite local configs if exist
+    Load site configs from GitHub, save them to local folder in $HOME
+    Overwrite local configs if exist.
     """
     read_default_site_config()
     config_dir = Path.home() / __LOCAL_CONFIG_DIR
@@ -297,7 +295,7 @@ def save_config():
 @site.command()
 def list():
     """
-    List site IDs
+    List all sites
     """
     read_site_config()
     for site_info in __site_config_data:
@@ -308,9 +306,14 @@ def list():
 @site_vo_params
 def env(site, vo):
     """
-    Generating OpenStack environment variables for site and VO
-    Does not set OS token, need to set separately, e.g. via oidc-token command
+    Generate OS environment variables for site
+    Does not set token environment variable, 
+    need to set separately (e.g. via oidc-token command)
     """
+    if site == "ALL_SITES":
+        print("Cannot generate environment variables for ALL_SITES")
+        raise click.Abort()
+
     endpoint, project_id, protocol = find_endpoint_and_project_id(site, vo)
     if endpoint:
         if protocol is None:
@@ -320,8 +323,7 @@ def env(site, vo):
         printSetEnvCommand("OS_IDENTITY_PROVIDER", "egi.eu")
         printSetEnvCommand("OS_PROTOCOL", protocol)
         printSetEnvCommand("OS_PROJECT_ID", project_id)
-        print("# Remember to set OS_ACCESS_TOKEN, e.g. :")
-        printSetEnvCommand("OS_ACCESS_TOKEN", "<token>")
+        printComment("Remember to also set OS_ACCESS_TOKEN")
     else:
-        print("VO %s not found on site %s" % (vo, site))
+        print("VO %s not found to have access to site %s" % (vo, site))
         return 1

--- a/fedcloudclient/sites.py
+++ b/fedcloudclient/sites.py
@@ -25,8 +25,7 @@ from fedcloudclient.decorators import (
     site_params,
     site_vo_params,
 )
-from fedcloudclient.shell import printSetEnvCommand
-from fedcloudclient.shell import printComment
+from fedcloudclient.shell import printSetEnvCommand, printComment
 from jsonschema import validate
 
 __REMOTE_CONFIG_FILE = (
@@ -249,7 +248,7 @@ def show(site):
     """
     Print configuration of specified site(s)
     """
-    if site == "ALL_SITES":        
+    if site == "ALL_SITES":
         read_site_config()
         for site_info in __site_config_data:
             site_info_str = yaml.dump(site_info, sort_keys=True)
@@ -307,7 +306,7 @@ def list():
 def env(site, vo):
     """
     Generate OS environment variables for site
-    Does not set token environment variable, 
+    Does not set token environment variable,
     need to set separately (e.g. via oidc-token command)
     """
     if site == "ALL_SITES":


### PR DESCRIPTION
There's a bug when multiple PowerShell instances are running, some of them are called `pwsh (2)` etc. and the parent process is not identified as PowerShell.

Added some cosmetic changes to the help messages.
Added some checks to commands that should not be used with ALL_SITES
Dropped command `fedcloud site show-all` in favor of `fedcloud site show --site=ALL_SITES`

Fixes #67 