### PR TITLE
Add missing quote in Cheat Sheet

### DIFF
--- a/docs/cheat.rst
+++ b/docs/cheat.rst
@@ -148,7 +148,7 @@ Searching and selecting resources
 ::
 
     # Shorter but more complex regex
-    $ fedcloud select image --site IFCA-LCG2 --vo training.egi.eu --image-specs "Name =~ 'EGI.*Ubuntu.*20.04"  --image-output list
+    $ fedcloud select image --site IFCA-LCG2 --vo training.egi.eu --image-specs "Name =~ 'EGI.*Ubuntu.*20.04'"  --image-output list
 
 
 Mapping and filtering results from OpenStack commands


### PR DESCRIPTION
Otherwise you get:
```
Error during constructing filter
Filter string:  $[?( Name =~ 'EGI.*Ubuntu.*20.04 )]
Unexpected EOF in string literal or identifier
```