### PR TITLE
Add a new "vos" command for endpoint

### DIFF
--- a/fedcloudclient/endpoint.py
+++ b/fedcloudclient/endpoint.py
@@ -266,6 +266,7 @@ def endpoint():
     Obtain endpoint details and scoped tokens
     """
 
+
 @endpoint.command()
 @all_site_params
 @oidc_params
@@ -282,11 +283,14 @@ def vos(
 
     project_list, project_error_list = get_projects_from_sites(access_token, site)
     if len(project_list) > 0:
-        vo_list = []
         for p in project_list:
             vo = find_vo_from_project_id(p[3], p[0])
             p.insert(0, vo)
-        print(tabulate(project_list, headers=["VO", "id", "Project name", "enabled", "site"]))
+        print(
+            tabulate(
+                project_list, headers=["VO", "id", "Project name", "enabled", "site"]
+            )
+        )
     else:
         print(f"Error: You probably do not have access to any project at site {site}")
         print(
@@ -294,7 +298,6 @@ def vos(
         )
     if len(project_error_list) > 0:
         print("[WARN] Sites not available: ", project_error_list, file=sys.stderr)
-
 
 
 @endpoint.command()

--- a/fedcloudclient/endpoint.py
+++ b/fedcloudclient/endpoint.py
@@ -24,6 +24,7 @@ from fedcloudclient.decorators import (
     site_params,
 )
 from fedcloudclient.shell import print_set_env_command
+from fedcloudclient.sites import find_vo_from_project_id
 
 OPENSTACK_NOVA = "org.openstack.nova"
 GOCDB_PUBLICURL = "https://goc.egi.eu/gocdbpi/public/"
@@ -264,6 +265,36 @@ def endpoint():
     """
     Obtain endpoint details and scoped tokens
     """
+
+@endpoint.command()
+@all_site_params
+@oidc_params
+def vos(
+    access_token,
+    site,
+    all_sites,
+):
+    """
+    List projects from site(s)
+    """
+    if site in ALL_SITES_KEYWORDS or all_sites:
+        site = None
+
+    project_list, project_error_list = get_projects_from_sites(access_token, site)
+    if len(project_list) > 0:
+        vo_list = []
+        for p in project_list:
+            vo = find_vo_from_project_id(p[3], p[0])
+            p.insert(0, vo)
+        print(tabulate(project_list, headers=["VO", "id", "Project name", "enabled", "site"]))
+    else:
+        print(f"Error: You probably do not have access to any project at site {site}")
+        print(
+            'Check your access token and VO memberships using "fedcloud token list-vos"'
+        )
+    if len(project_error_list) > 0:
+        print("[WARN] Sites not available: ", project_error_list, file=sys.stderr)
+
 
 
 @endpoint.command()

--- a/fedcloudclient/sites.py
+++ b/fedcloudclient/sites.py
@@ -237,6 +237,27 @@ def find_endpoint_and_project_id(site_name, vo):
     return None, None, None
 
 
+def find_vo_from_project_id(site_name, project_id):
+    """
+    Return the VO name form the project ID and site_name according
+    to site configuration
+
+    :param site_name: site ID in GOCDB
+    :param project_id: project_id configured to support the VO
+    :return: vo if the VO is configured, otherwise None
+    """
+    site_info = find_site_data(site_name)
+    if site_info is None:
+        return None
+
+    for vo_info in site_info["vos"]:
+        if vo_info.get("auth", {}).get("project_id", None) == project_id:
+            return vo_info["name"]
+
+    # Return None if the project is not found
+    return None
+
+
 @click.group()
 def site():
     """


### PR DESCRIPTION
This command will map the project ids to the VO names declared for sites
so users can have better understanding of what are the VOs actually
supported at every site for them
