### PR TITLE
Remove Kharkov

### DIFF
--- a/config/sites.yaml
+++ b/config/sites.yaml
@@ -19,7 +19,6 @@
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/INFN-CLOUD-BARI.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/INFN-CLOUD-CNAF.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/INFN-PADOVA-STACK.yaml"
-- "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/Kharkov-KIPT-LCG2.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/NCG-INGRID-PT.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/SCAI.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/TR-FC1-ULAKBIM.yaml"


### PR DESCRIPTION
I think this site has been removed: https://github.com/EGI-Federation/fedcloud-catchall-operations/pull/216
and it is affecting operation

```
egiilm@tckr:~$ fedcloud site list

Error during reading data from https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/Kharkov-KIPT-LCG2.yaml
```


It would be good to either retrieve this list dynamically from somewhere or to implement exception management in the same way we did for the certificates, so the program operation is not interrupted if one of these YAML files cannot be accessed.
