### PR TITLE
Adding missing Ilifu site

### DIFF
--- a/config/sites.yaml
+++ b/config/sites.yaml
@@ -14,6 +14,7 @@
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/GSI-LCG2.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/IFCA-LCG2.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/IISAS-FedCloud-cloud.yaml"
+- "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/ILIFU-UCT.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/IN2P3-IRES.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/INFN-CATANIA-STACK.yaml"
 - "https://raw.githubusercontent.com/EGI-Foundation/fedcloud-catchall-operations/main/sites/INFN-CLOUD-BARI.yaml"


### PR DESCRIPTION
Noticed that the Ilifu/UCT site was missing when testing out command line access.  Opening a pull request to get that updated following a conversation with @enolfc .